### PR TITLE
Fixes for Coop Operation mode and Stackable items

### DIFF
--- a/CSGSI/Nodes/MapNode.cs
+++ b/CSGSI/Nodes/MapNode.cs
@@ -46,6 +46,7 @@ namespace CSGSI.Nodes
         /// Arms Race & Demolition
         /// </summary>
         GunGameTRBomb,
+        CoopMission,
         Custom
     }
 }

--- a/CSGSI/Nodes/WeaponNode.cs
+++ b/CSGSI/Nodes/WeaponNode.cs
@@ -40,7 +40,8 @@ namespace CSGSI.Nodes
         Pistol,
         Knife,
         Grenade,
-        C4
+        C4,
+        StackableItem
     }
 
     public enum WeaponState


### PR DESCRIPTION
The new operation introduced a Coop mode, as well as Epipens which are stackable. This addresses both of these changes.