### PR TITLE
Fixes #35 & #36

### DIFF
--- a/CSGSI/Nodes/NodeBase.cs
+++ b/CSGSI/Nodes/NodeBase.cs
@@ -22,7 +22,7 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Whether or not this node contains data (i.e. JSON string is not empty)
         /// </summary>
-        public bool HasData => !string.IsNullOrWhiteSpace(JSON) || JSON.Equals("{}");
+        public bool HasData => !string.IsNullOrWhiteSpace(JSON) || !JSON.Equals("{}");
 
         internal NodeBase(string json)
         {

--- a/CSGSI/Nodes/NodeBase.cs
+++ b/CSGSI/Nodes/NodeBase.cs
@@ -22,7 +22,7 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Whether or not this node contains data (i.e. JSON string is not empty)
         /// </summary>
-        public bool HasData => !string.IsNullOrWhiteSpace(JSON);
+        public bool HasData => !string.IsNullOrWhiteSpace(JSON) || JSON.Equals("{}");
 
         internal NodeBase(string json)
         {

--- a/CSGSI/Nodes/WeaponNode.cs
+++ b/CSGSI/Nodes/WeaponNode.cs
@@ -131,7 +131,12 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Melee weapons (such as hammer/wrench) in Danger Zone.
         /// </summary>
-        Melee
+        Melee,
+
+        /// <summary>
+        /// Bump mine in Danger Zone.
+        /// </summary>
+        BumpMine
     }
 
     /// <summary>


### PR DESCRIPTION
`HasData` only returned false when the JSON was empty. However, the JSON can also be an opening and closing curly braces.