### PR TITLE
Fixes `HasData` check (#35)

### DIFF
--- a/CSGSI/Nodes/NodeBase.cs
+++ b/CSGSI/Nodes/NodeBase.cs
@@ -12,7 +12,7 @@ namespace CSGSI.Nodes
         /// <summary>
         /// The data that was passed via JSON.
         /// </summary>
-        protected JObject _data;
+        protected readonly JObject _data;
 
         /// <summary>
         /// The raw JSON string that was used to construct this node.
@@ -22,7 +22,7 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Whether or not this node contains data (i.e. JSON string is not empty)
         /// </summary>
-        public bool HasData => !string.IsNullOrWhiteSpace(JSON);
+        public bool HasData { get; private set; }
 
         internal NodeBase(string json)
         {
@@ -31,6 +31,7 @@ namespace CSGSI.Nodes
             if (json.Equals("") || json.Equals("true", StringComparison.InvariantCultureIgnoreCase))
             {
                 json = "{}";
+                HasData = false;
             }
             _data = JObject.Parse(json);
             JSON = json;

--- a/CSGSI/Nodes/WeaponNode.cs
+++ b/CSGSI/Nodes/WeaponNode.cs
@@ -131,7 +131,12 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Melee weapons (such as hammer/wrench) in Danger Zone.
         /// </summary>
-        Melee
+        Melee,
+
+        /// <summary>
+        /// Bump mine in Danger Zone.
+        /// </summary>
+        BumpMine
     }
 
     /// <summary>

--- a/CSGSI/Nodes/WeaponNode.cs
+++ b/CSGSI/Nodes/WeaponNode.cs
@@ -131,12 +131,7 @@ namespace CSGSI.Nodes
         /// <summary>
         /// Melee weapons (such as hammer/wrench) in Danger Zone.
         /// </summary>
-        Melee,
-
-        /// <summary>
-        /// Bump mine in Danger Zone.
-        /// </summary>
-        BumpMine
+        Melee
     }
 
     /// <summary>


### PR DESCRIPTION
The constructor already checks whether the object is empty. Since the information is read-only, set `HasData` from there.